### PR TITLE
Add working Colab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ This codebase is a slightly modified version of [ganshowcase](https://github.com
 
 ## Usage
 
+Note: You can use [this Google Colab notebook](https://colab.research.google.com/drive/1WmZRWG1L1_SuBwDVyiexcLkGSn8gqYap?usp=sharing) to train a model without needing to install anything on your computer.
+
 #### 1) Download this repository
 
 ```bash
-git clone https://github.com/noisyneuron/training-dcgan
+git clone https://github.com/ml5js/training-dcgan
 cd training-dcgan
 ```
 


### PR DESCRIPTION
I'd ideally like to have submitted this as an issue rather than a pull request (but this repo has issues disabled), since it would probably be a good idea for a regular contributor to fork the colab and replace it with their own colab link. I did consider adding the ipynb file itself to the repo, but this notebook is optimised for colab, and won't work elsewhere. Thanks!